### PR TITLE
BOAPI-1096 fix(typecheck): delete {:ok, decimal} case

### DIFF
--- a/lib/type.ex
+++ b/lib/type.ex
@@ -63,8 +63,6 @@ defmodule Tarams.Type do
 
   defp cast_decimal(term) when is_binary(term) do
     case Decimal.parse(term) do
-      {:ok, decimal} -> check_decimal(decimal, false)
-      # The following two clauses exist to support earlier versions of Decimal.
       {decimal, ""} -> check_decimal(decimal, false)
       {_, remainder} when is_binary(remainder) and byte_size(remainder) > 0 -> :error
       :error -> :error

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Tarams.MixProject do
   def project do
     [
       app: :tarams,
-      version: "1.6.1-ecc",
+      version: "1.6.2-ecc",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
В elixir 1.19 TypeCheck стал более строгим.  
У `cast_decimal` есть мёртвая ветка case:
```shell
==> tarams
Compiling 4 files (.ex)
    warning: the following clause will never match:

        {:ok, decimal}

    because it attempts to match on the result of:

        Decimal.parse(term)

    which has type:

        dynamic(
          :error or
            {%Decimal{sign: integer(), coef: integer(), exp: float() or integer()} or
               %Decimal{sign: integer(), coef: :NaN or :inf, exp: integer()}, term()}
        )

    typing violation found at:
    │
 66 │       {:ok, decimal} -> check_decimal(decimal, false)
    │       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/type.ex:66: Tarams.Type.cast_decimal/1
```